### PR TITLE
Update default values for helm chart.

### DIFF
--- a/helm-chart/jackil-docker-gc/values.yaml
+++ b/helm-chart/jackil-docker-gc/values.yaml
@@ -1,8 +1,8 @@
 # Default values for docker-gc.
 image:
-  repository: jackil/docker-gc
+  repository: airsharedcontainers.azurecr.io/docker-gc
   tag: latest
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 docker:
   socketPath: /var/run/docker.sock
   volumeName: docker-volume
@@ -21,11 +21,15 @@ config:
   #strategy: ByDiskSpace
   #sizeLimitInGigabyte:
   containerStateBlacklist: dead,exited
-resources:
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
 


### PR DESCRIPTION
Do not use default resource limits, instead allow the conscious choice by users.
Use the Azure Shared containers image repository for docker-gc image.